### PR TITLE
Change petitions id to uuid

### DIFF
--- a/app/models/decidim/petitions/petition.rb
+++ b/app/models/decidim/petitions/petition.rb
@@ -24,15 +24,6 @@ module Decidim
         title["en"]
       end
 
-      def community_id
-        SecureRandom.hex(20)
-      end
-
-      def attribute_id
-        # (Decidim.config.application_name + "-" + title["en"]).downcase.tr(" ", "-")
-        "#{Decidim.config.application_name}-#{title["en"].parameterize}"
-      end
-
       def closed?
         state == "closed"
       end

--- a/db/migrate/20190627170805_add_uuid_to_petitions.rb
+++ b/db/migrate/20190627170805_add_uuid_to_petitions.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class AddUuidToPetitions < ActiveRecord::Migration[5.2]
+  def up
+    enable_extension "uuid-ossp"
+    enable_extension "pgcrypto"
+    add_column :decidim_petitions_petitions, :uuid, :uuid, default: "gen_random_uuid()", null: false
+
+    change_table :decidim_petitions_petitions do |t|
+      t.remove :id
+      t.rename :uuid, :id
+    end
+
+    execute "ALTER TABLE decidim_petitions_petitions ADD PRIMARY KEY (id)"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/lib/decidim/petitions/decode/connector.rb
+++ b/lib/decidim/petitions/decode/connector.rb
@@ -12,7 +12,7 @@ module Decidim
           Decidim::Petitions::Decode::Services::DDDCCredentialIssuerAPI.new(
             settings_credentials_issuer_api
           ).create(
-            attribute_id: petition.attribute_id,
+            attribute_id: petition.id,
             attribute_info: petition.json_attribute_info,
             attribute_info_optional: petition.json_attribute_info_optional,
             hash_attributes: true,
@@ -24,8 +24,8 @@ module Decidim
           Decidim::Petitions::Decode::Services::BarcelonaNow.new(
             settings_dashboard_api
           ).create(
-            authorizable_attribute_id: petition.attribute_id,
-            community_id: petition.community_id,
+            authorizable_attribute_id: petition.id,
+            community_id: petition.id,
             community_name: petition.community_name,
             credential_issuer_endpoint_address: petition.component.settings.credential_issuer_api_url
           )
@@ -39,7 +39,7 @@ module Decidim
 
         def create_dddc_petition
           dddc_petitions.create(
-            petition_id: petition.attribute_id,
+            petition_id: petition.id,
             credential_issuer_url: petition.component.settings.credential_issuer_api_url,
             credential_issuer_petition_value: petition_value
           )

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "spec_helper"
+
 module Decidim
   module Petitions
     describe Petition do
@@ -18,16 +20,8 @@ module Decidim
         expect(subject.community_name).to eq(subject.title["en"])
       end
 
-      it "return community_id" do
-        expect(subject.community_id).not_to be nil
-      end
-
       it "return body en" do
         expect(subject.body).to eq(subject.title)
-      end
-
-      it "return attribute_id" do
-        expect(subject.attribute_id).to match(subject.title["en"].parameterize)
       end
 
       context "when petition is closed" do


### PR DESCRIPTION
This change the petition ID to a UUID for use as petition_id in the integration with decode petitions api and credential issuer.