### PR TITLE
Refactorize graphql for petitions and specs

### DIFF
--- a/app/types/decidim/petitions/petition_type.rb
+++ b/app/types/decidim/petitions/petition_type.rb
@@ -17,6 +17,7 @@ module Decidim
 
       field :description, JSONType, "Description of the petition."
       field :json_schema, JSONType, "JSON Schema for DECODE"
+      field :json_attribute_info, JSONType, "JSON Attribute Info DECODE"
       field :json_attribute_info_optional, JSONType, "JSON Attribute Info Optional for DECODE"
 
       field :image, !types.String, "Petition image square" do
@@ -24,10 +25,10 @@ module Decidim
       end
       field :attribute_id, !types.String, "Attribute ID for Decode APIs"
       field :credential_issuer_api_url, !types.String, "Credential Issuer API URL for Decode APIs" do
-        resolve ->(_obj, _args, _ctx) { Rails.application.secrets.decode[:credential_issuer][:url] }
+        resolve ->(obj, _args, _ctx) { obj.component.settings.credential_issuer_api_url }
       end
       field :petitions_api_url, !types.String, "Petitions API URL for Decode APIs" do
-        resolve ->(_obj, _args, _ctx) { Rails.application.secrets.decode[:petitions][:url] }
+        resolve ->(obj, _args, _ctx) { obj.component.settings.petitions_api_url }
       end
     end
 

--- a/lib/decidim/petitions/query_extensions.rb
+++ b/lib/decidim/petitions/query_extensions.rb
@@ -5,19 +5,23 @@ module Decidim
     module QueryExtensions
       def self.define(type)
         type.field :petition do
-          type !PetitionType
+          type PetitionType
 
           argument :id, !types.ID, "The petition ID"
 
-          resolve lambda { |_obj, args, _ctx|
-            Petition.find_by(id: args[:id])
+          resolve lambda { |_obj, args, ctx|
+            petition = Petition.find_by(id: args[:id])
+            return nil unless petition&.organization == ctx[:current_organization]
+            petition
           }
         end
 
         type.field :petitions do
           type types[PetitionType]
-          resolve lambda { |_obj, _args, _ctx|
-            Petition.all
+          resolve lambda { |_obj, _args, ctx|
+            Petition.all.select do |petition|
+              petition.organization == ctx[:current_organization]
+            end
           }
         end
       end

--- a/spec/shared/manage_petition_examples.rb
+++ b/spec/shared/manage_petition_examples.rb
@@ -7,26 +7,28 @@ shared_examples "manage petitions" do
   let(:json_attribute_info) { Decidim::Petitions::Faker.json_attribute_info }
   let(:json_attribute_info_optional) { Decidim::Petitions::Faker.json_attribute_info_optional }
 
-  it "update a petition" do
-    within find("tr", text: translated(petition.title)) do
-      click_link "Edit"
-    end
+  describe "updating a petition" do
+    it "update a petition" do
+      within find("tr", text: translated(petition.title)) do
+        click_link "Edit"
+      end
 
-    within ".edit_petition" do
-      fill_in_i18n(
-        :petition_title,
-        "#petition-title-tabs",
-        en: "My new title",
-        es: "Mi nuevo título",
-        ca: "El meu nou títol"
-      )
-      find("*[type=submit]").click
-    end
+      within ".edit_petition" do
+        fill_in_i18n(
+          :petition_title,
+          "#petition-title-tabs",
+          en: "My new title",
+          es: "Mi nuevo título",
+          ca: "El meu nou títol"
+        )
+        find("*[type=submit]").click
+      end
 
-    expect(page).to have_admin_callout("The petition was updated successfully")
+      expect(page).to have_admin_callout("The petition was updated successfully")
 
-    within "table" do
-      expect(page).to have_content("My new title")
+      within "table" do
+        expect(page).to have_content("My new title")
+      end
     end
   end
 
@@ -65,76 +67,82 @@ shared_examples "manage petitions" do
     end
   end
 
-  it "activate a petition" do
-    within find("tr", text: translated(petition.title)) do
-      accept_confirm { click_link "Open petition" }
-    end
+  describe "activating a petition" do
+    it "activate a petition" do
+      within find("tr", text: translated(petition.title)) do
+        accept_confirm { click_link "Open petition" }
+      end
 
-    expect(page).to have_admin_callout("The petition was opened successfully")
+      expect(page).to have_admin_callout("The petition was opened successfully")
 
-    petition.reload
-    expect(petition.opened?).to be true
-  end
-
-  it "update invalid petition" do
-    within find("tr", text: translated(petition.title)) do
-      click_link "Edit"
-    end
-
-    within ".edit_petition" do
-      fill_in :petition_json_schema, with: ""
-    end
-
-    find("*[type=submit]").click
-
-    within ".edit_petition" do
-      expect(page).to have_content("There's an error in this field.")
+      petition.reload
+      expect(petition.opened?).to be true
     end
   end
 
-  it "create a new petition", :slow do
-    find(".card-title a.button").click
+  describe "updating an invalid petition" do
+    it "update invalid petition" do
+      within find("tr", text: translated(petition.title)) do
+        click_link "Edit"
+      end
 
-    fill_in_i18n(
-      :petition_title,
-      "#petition-title-tabs",
-      en: "My petition",
-      es: "Mi petición",
-      ca: "El meu petition"
-    )
+      within ".edit_petition" do
+        fill_in :petition_json_schema, with: ""
+      end
 
-    fill_in_i18n_editor(
-      :petition_summary,
-      "#petition-summary-tabs",
-      en: "Summary of my petition",
-      es: "Summary mi petición",
-      ca: "Summary el meu petition"
-    )
-
-    fill_in_i18n_editor(
-      :petition_description,
-      "#petition-description-tabs",
-      en: "Description my petition",
-      es: "Description mi petición",
-      ca: "Description El meu petition"
-    )
-
-    fill_in_i18n(
-      :petition_instructions_url,
-      "#petition-instructions_url-tabs",
-      en: "https://petition.example.org/en",
-      es: "https://petition.example.org/es",
-      ca: "https://petition.example.org/ca"
-    )
-
-    fill_in :petition_json_schema, with: json_schema.to_json
-    fill_in :petition_json_attribute_info, with: json_attribute_info.to_json
-    fill_in :petition_json_attribute_info_optional, with: json_attribute_info_optional.to_json
-
-    within ".new_petition" do
       find("*[type=submit]").click
-    end
 
-    expect(page).to have_admin_callout("The petition was created successfully")
+      within ".edit_petition" do
+        expect(page).to have_content("There's an error in this field.")
+      end
+    end
+  end
+
+  describe "creating a petition" do
+    it "create a new petition", :slow do
+      find(".card-title a.button").click
+
+      fill_in_i18n(
+        :petition_title,
+        "#petition-title-tabs",
+        en: "My petition",
+        es: "Mi petición",
+        ca: "El meu petition"
+      )
+
+      fill_in_i18n_editor(
+        :petition_summary,
+        "#petition-summary-tabs",
+        en: "Summary of my petition",
+        es: "Summary mi petición",
+        ca: "Summary el meu petition"
+      )
+
+      fill_in_i18n_editor(
+        :petition_description,
+        "#petition-description-tabs",
+        en: "Description my petition",
+        es: "Description mi petición",
+        ca: "Description El meu petition"
+      )
+
+      fill_in_i18n(
+        :petition_instructions_url,
+        "#petition-instructions_url-tabs",
+        en: "https://petition.example.org/en",
+        es: "https://petition.example.org/es",
+        ca: "https://petition.example.org/ca"
+      )
+
+      fill_in :petition_json_schema, with: json_schema.to_json
+      fill_in :petition_json_attribute_info, with: json_attribute_info.to_json
+      fill_in :petition_json_attribute_info_optional, with: json_attribute_info_optional.to_json
+
+      within ".new_petition" do
+        find("*[type=submit]").click
+      end
+
+      expect(page).to have_admin_callout("The petition was created successfully")
+    end
   end
 end

--- a/spec/types/petition_type_spec.rb
+++ b/spec/types/petition_type_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/api/test/type_context"
+
+module Decidim::Petitions
+  describe PetitionType do
+    include_context "with a graphql type"
+
+    let(:model) { create(:petition) }
+
+    describe "id" do
+      let(:query) { "{ id }" }
+
+      it "returns the petition uuid" do
+        expect(response).to include("id" => model.id)
+      end
+    end
+
+    describe "credential_issuer_url" do
+      let(:query) { "{ credential_issuer_api_url }" }
+
+      it "returns the component credential_issuer_api_url" do
+        expect(response).to include("credential_issuer_api_url" => model.component.settings.credential_issuer_api_url)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change the logic for render petitions using the context of the current organization (for multi-tenancy), also add missing fields for type petitions and add specs.